### PR TITLE
use sbt 0.13.9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.8
+sbt.version=0.13.9
 


### PR DESCRIPTION
:innocent: 

> According to sbt/sbt#2217, there had been some misconfiguration of redirection (https to http) at JCenter, and it's now fixed. Could you try sbt 0.13.9 and see if it works?

https://github.com/scalikejdbc/ddd-repository-example/pull/1#issuecomment-144186408
